### PR TITLE
Observe keys that carry more than one real modifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PLUGIN_DIR ?= $(HOME)/.config/omarchy/plugins/huacnlee.which-key
 
 test:
 	bash tests/test_install.sh
+	bash tests/test_install_compound_modmap.sh
 	bash tests/test_bindings.sh
 	node tests/test_model.js
 	node tests/test_settings.js

--- a/scripts/install-bindings
+++ b/scripts/install-bindings
@@ -55,9 +55,16 @@ awk '
     next
   }
   match($0, /^  ([A-Za-z0-9_]+):$/, p) { key = p[1]; next }
-  match($0, /^[[:space:]]+real:[[:space:]]+(Shift|Control|Mod1|Mod4)$/, p) && code[key] {
-    role = p[1] == "Shift" ? "shift" : (p[1] == "Control" ? "ctrl" : (p[1] == "Mod1" ? "alt" : "super"))
-    bit = p[1] == "Shift" ? 1 : (p[1] == "Control" ? 4 : (p[1] == "Mod1" ? 8 : 64))
+  match($0, /^[[:space:]]+real:[[:space:]]+([A-Za-z0-9 +]+)$/, p) && code[key] {
+    n = split(p[1], parts, /[[:space:]]*\+[[:space:]]*/)
+    real = ""
+    for (i = 1; i <= n; i++) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", parts[i])
+      if (parts[i] == "Shift" || parts[i] == "Control" || parts[i] == "Mod1" || parts[i] == "Mod4") { real = parts[i]; break }
+    }
+    if (real == "") next
+    role = real == "Shift" ? "shift" : (real == "Control" ? "ctrl" : (real == "Mod1" ? "alt" : "super"))
+    bit = real == "Shift" ? 1 : (real == "Control" ? 4 : (real == "Mod1" ? 8 : 64))
     count[role]++
     print code[key], role "_" count[role], bit
   }

--- a/tests/test_install_compound_modmap.sh
+++ b/tests/test_install_compound_modmap.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Regression test: a key that carries more than one real modifier must still be
+# observed. Omarchy's default kb_options include shift:both_capslock_cancel,
+# which maps Left Shift to both Shift and Lock, so xkbcli reports
+# "real: Shift + Lock" for LFSH. An exact single-modifier match drops that key
+# and Super + Left Shift never updates the modifier mask.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+config="$test_root/bindings.lua"
+fake_xkbcli="$test_root/xkbcli"
+fake_hyprctl="$test_root/hyprctl"
+
+assert_file_contains() {
+  local file="$1" pattern="$2" message="$3"
+  if ! grep -Fq -- "$pattern" "$file"; then
+    printf 'FAIL: %s\nmissing: %s\n' "$message" "$pattern" >&2
+    exit 1
+  fi
+}
+
+cat >"$config" <<'LUA'
+-- User bindings before which-key.
+o.bind("SUPER + B", "Browser", "browser")
+LUA
+
+cat >"$fake_xkbcli" <<'SH'
+#!/bin/bash
+test "${1:-}" = compile-keymap
+if [[ "$*" == *'--modmaps'* ]]; then
+cat <<'MODMAPS'
+Keys modifier maps:
+  LFSH:
+    real:    Shift + Lock
+    virtual: 0
+  RTSH:
+    real:    Shift
+    virtual: 0
+  LCTL:
+    real:    Control
+    virtual: 0
+  LALT:
+    real:    Mod1
+    virtual: Alt
+  LWIN:
+    real:    Mod4
+    virtual: Super
+MODMAPS
+exit 0
+fi
+cat <<'KEYMAP'
+xkb_keycodes "evdev" {
+  <LFSH> = 50;
+  <RTSH> = 62;
+  <LCTL> = 37;
+  <LALT> = 64;
+  <LWIN> = 133;
+};
+KEYMAP
+SH
+chmod +x "$fake_xkbcli"
+
+cat >"$fake_hyprctl" <<'SH'
+#!/bin/bash
+case "${3:-}" in
+  input:kb_options) printf '%s\n' '{"str":"compose:caps,shift:both_capslock_cancel"}' ;;
+  *) printf '%s\n' '{"str":""}' ;;
+esac
+SH
+chmod +x "$fake_hyprctl"
+
+OMARCHY_WHICH_KEY_XKBCLI="$fake_xkbcli" \
+OMARCHY_WHICH_KEY_HYPRCTL="$fake_hyprctl" \
+OMARCHY_WHICH_KEY_HYPR_CONFIG="$config" "$repo_root/scripts/install-bindings"
+
+assert_file_contains "$config" '[50] = { name = "shift_1", bit = 1 }' \
+  "Left Shift mapped to Shift + Lock should still update the modifier mask"
+assert_file_contains "$config" '[62] = { name = "shift_2", bit = 1 }' \
+  "Right Shift should keep being observed alongside it"
+assert_file_contains "$config" '[37] = { name = "ctrl_1", bit = 4 }' \
+  "single-modifier keys should be unaffected by compound handling"
+assert_file_contains "$config" '[64] = { name = "alt_1", bit = 8 }' \
+  "Alt should follow the active XKB modifier map"
+assert_file_contains "$config" '[133] = { name = "super_1", bit = 64 }' \
+  "Super should follow the active XKB modifier map"
+
+if grep -Fq 'name = "lock' "$config"; then
+  printf 'FAIL: Lock is not a tracked modifier and must not be emitted\n' >&2
+  exit 1
+fi
+
+OMARCHY_TEST_CONFIG="$config" \
+  lua -e 'assert(loadfile(os.getenv("OMARCHY_TEST_CONFIG")))'
+
+printf 'test_install_compound_modmap: ok\n'


### PR DESCRIPTION
On Omarchy, holding `Super + Left Shift` never advances the guide to the `Super + Shift` page. `Super + Right Shift` works. The cause is that Left Shift is missing from the generated `omarchy_which_key_codes` table.

## Cause

`xkbcli compile-keymap --modmaps` lists every real modifier a key belongs to, joining them with `" + "`. The extraction in `scripts/install-bindings` anchored on exactly one modifier name:

```awk
match($0, /^[[:space:]]+real:[[:space:]]+(Shift|Control|Mod1|Mod4)$/, p) && code[key]
```

A key in two modifier groups prints `real:    Shift + Lock`, which never matches, so the key is dropped with no error.

Omarchy ships `shift:both_capslock_cancel` in its default `kb_options` (`default/hypr/input.lua`), which puts Left Shift in the Lock group as well as Shift:

```
modifier_map Shift { <LFSH>, <RTSH> };
modifier_map Lock { <LFSH> };
```

so `xkbcli` reports:

```
  LFSH:                      RTSH:
    real:    Shift + Lock      real:    Shift
```

Left Shift is skipped, Right Shift survives. Holding `Super + Left Shift` leaves the mask at `64` instead of `65`. This affects any Omarchy install on the default `kb_options`, and any layout whose keymap puts a modifier key in two groups.

Observed on Omarchy 4.0.2-1, Hyprland 0.56.2, `kb_layout us,hr`, `kb_options compose:caps,shift:both_capslock_cancel`.

## Fix

Split the `real:` list on `+` and take the first tracked modifier. Single-modifier lines behave exactly as before, and keys mapping only to untracked modifiers (such as `Lock` alone) are still ignored.

Before / after on the affected machine:

```lua
-- before
[37] = { name = "ctrl_1", bit = 4 },
[62] = { name = "shift_1", bit = 1 },   -- Right Shift only

-- after
[37] = { name = "ctrl_1", bit = 4 },
[50] = { name = "shift_1", bit = 1 },   -- Left Shift restored
[62] = { name = "shift_2", bit = 1 },
```

## Tests

Adds `tests/test_install_compound_modmap.sh`, which stubs `xkbcli` with a `Shift + Lock` modmap and asserts both Shift keys are observed, that single-modifier keys are unaffected, and that `Lock` is not emitted as a tracked modifier. It fails on `main` with:

```
FAIL: Left Shift mapped to Shift + Lock should still update the modifier mask
missing: [50] = { name = "shift_1", bit = 1 }
```

and passes with the fix. Registered in the `Makefile`; full `make test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4gE9RKu7dywgXvmcGGZgk